### PR TITLE
Add WithdrawalBonded event for bondWithdrawalAndDistribute

### DIFF
--- a/contracts/bridges/Bridge.sol
+++ b/contracts/bridges/Bridge.sol
@@ -36,10 +36,7 @@ abstract contract Bridge is Accounting {
 
     event WithdrawalBonded(
         bytes32 indexed transferId,
-        address indexed recipient,
-        uint256 amount,
-        bytes32 transferNonce,
-        uint256 bonderFee
+        uint256 amount
     );
 
     event WithdrawalBondSettled(
@@ -235,8 +232,6 @@ abstract contract Bridge is Accounting {
 
         _bondWithdrawal(transferId, amount);
         _fulfillWithdraw(transferId, recipient, amount, bonderFee);
-
-        emit WithdrawalBonded(transferId, recipient, amount, transferNonce, bonderFee);
     }
 
     /**
@@ -351,6 +346,8 @@ abstract contract Bridge is Accounting {
         require(_bondedWithdrawalAmounts[msg.sender][transferId] == 0, "BRG: Withdrawal has already been bonded");
         _addDebit(msg.sender, amount);
         _bondedWithdrawalAmounts[msg.sender][transferId] = amount;
+
+        emit WithdrawalBonded(transferId, amount);
     }
 
     /* ========== Private Functions ========== */

--- a/contracts/bridges/L2_Bridge.sol
+++ b/contracts/bridges/L2_Bridge.sol
@@ -223,6 +223,8 @@ abstract contract L2_Bridge is Bridge {
         _bondWithdrawal(transferId, amount);
         _markTransferSpent(transferId);
         _distribute(recipient, amount, amountOutMin, deadline, bonderFee);
+
+        emit WithdrawalBonded(transferId, recipient, amount, transferNonce, bonderFee);
     }
 
     /**

--- a/contracts/bridges/L2_Bridge.sol
+++ b/contracts/bridges/L2_Bridge.sol
@@ -223,8 +223,6 @@ abstract contract L2_Bridge is Bridge {
         _bondWithdrawal(transferId, amount);
         _markTransferSpent(transferId);
         _distribute(recipient, amount, amountOutMin, deadline, bonderFee);
-
-        emit WithdrawalBonded(transferId, recipient, amount, transferNonce, bonderFee);
     }
 
     /**


### PR DESCRIPTION
The `WithdrawalBonded` event exists for `bondWithdrawal` but not for `bondWithdrawalAndDistribute`.