### PR TITLE
Feature/audit fixes

### DIFF
--- a/config/utils.ts
+++ b/config/utils.ts
@@ -67,9 +67,7 @@ export const getL2BridgeDefaults = (
     const defaultGasLimit = DEFAULT_MESSENGER_WRAPPER_GAS_LIMIT
     additionalData.push(defaultGasLimit)
   } else if (isChainIdXDai(chainId)) {
-    const isAmbL1: boolean = false
-    const ambAddress: string = getXDaiAmbAddresses(isAmbL1)
-    additionalData.push(l1ChainId, ambAddress)
+    additionalData.push(l1ChainId)
   }
 
   defaults.push(

--- a/contracts/bridges/Accounting.sol
+++ b/contracts/bridges/Accounting.sol
@@ -127,10 +127,10 @@ abstract contract Accounting {
     }
 
     /**
-     * @dev Allows the bonder to withdraw any available balance and add to its debit balance
+     * @dev Allows the caller to withdraw any available balance and add to their debit balance
      * @param amount The amount being staked
      */
-    function unstake(uint256 amount) external requirePositiveBalance onlyBonder {
+    function unstake(uint256 amount) external requirePositiveBalance {
         _addDebit(msg.sender, amount);
         _transferFromBridge(msg.sender, amount);
     }

--- a/contracts/bridges/Bridge.sol
+++ b/contracts/bridges/Bridge.sol
@@ -256,8 +256,9 @@ abstract contract Bridge is Accounting {
         bytes32 transferRootId = getTransferRootId(rootHash, transferRootTotalAmount);
 
         uint256 amount = _bondedWithdrawalAmounts[bonder][transferId];
-        _bondedWithdrawalAmounts[bonder][transferId] = 0;
+        require(amount > 0, "L2_BRG: transferId has no bond");
 
+        _bondedWithdrawalAmounts[bonder][transferId] = 0;
         _addToAmountWithdrawn(transferRootId, amount);
         _addCredit(bonder, amount);
 
@@ -289,8 +290,10 @@ abstract contract Bridge is Accounting {
         uint256 totalBondsSettled = 0;
         for(uint256 i = 0; i < transferIds.length; i++) {
             uint256 transferBondAmount = _bondedWithdrawalAmounts[bonder][transferIds[i]];
-            totalBondsSettled = totalBondsSettled.add(transferBondAmount);
-            _bondedWithdrawalAmounts[bonder][transferIds[i]] = 0;
+            if (transferBondAmount > 0) {
+                totalBondsSettled = totalBondsSettled.add(transferBondAmount);
+                _bondedWithdrawalAmounts[bonder][transferIds[i]] = 0;
+            }
         }
 
         _addToAmountWithdrawn(transferRootId, totalBondsSettled);

--- a/contracts/bridges/Bridge.sol
+++ b/contracts/bridges/Bridge.sol
@@ -277,7 +277,13 @@ abstract contract Bridge is Accounting {
     )
         external
     {
-        bytes32 rootHash = MerkleUtils.getMerkleRoot(transferIds);
+        // Make deep copy of transferIds because getMerkleRoot will mutate it
+        bytes32[] memory leaves = new bytes32[](transferIds.length);
+        for (uint256 i = 0; i < transferIds.length; i++) {
+            leaves[i] = transferIds[i];
+        }
+
+        bytes32 rootHash = MerkleUtils.getMerkleRoot(leaves);
         bytes32 transferRootId = getTransferRootId(rootHash, totalAmount);
 
         uint256 totalBondsSettled = 0;

--- a/contracts/bridges/L1_Bridge.sol
+++ b/contracts/bridges/L1_Bridge.sol
@@ -297,7 +297,7 @@ abstract contract L1_Bridge is Bridge {
                 // that Bonders are not punished if a TransferRoot is bonded too soon in error.
 
                 // Return the challenger's stake
-                _transferFromBridge(transferBond.challenger, challengeStakeAmount);
+                _addCredit(transferBond.challenger, challengeStakeAmount);
                 // Credit the bonder back with the bond amount
                 _addCredit(transferBond.bonder, getBondForTransferAmount(originalAmount));
             }
@@ -306,7 +306,7 @@ abstract contract L1_Bridge is Bridge {
             // Burn 25% of the challengers stake
             _transferFromBridge(address(0xdead), challengeStakeAmount.mul(1).div(4));
             // Reward challenger with the remaining 75% of their stake plus 100% of the Bonder's stake
-            _transferFromBridge(transferBond.challenger, challengeStakeAmount.mul(7).div(4));
+            _addCredit(transferBond.challenger, challengeStakeAmount.mul(7).div(4));
         }
 
         emit ChallengeResolved(transferRootId, rootHash, originalAmount);

--- a/contracts/bridges/L1_Bridge.sol
+++ b/contracts/bridges/L1_Bridge.sol
@@ -39,8 +39,7 @@ abstract contract L1_Bridge is Bridge {
     uint256 public timeSlotSize = 3 hours;
     uint256 public challengePeriod = 1 days;
     uint256 public challengeResolutionPeriod = 10 days;
-
-    uint256 constant MIN_TRANSFER_ROOT_BOND_DELAY = 15 minutes;
+    uint256 public minTransferRootBondDelay = 15 minutes;
 
     /* ========== Events ========== */
 
@@ -361,6 +360,10 @@ abstract contract L1_Bridge is Bridge {
 
     function setChallengeResolutionPeriod(uint256 _challengeResolutionPeriod) external onlyGovernance {
         challengeResolutionPeriod = _challengeResolutionPeriod;
+    }
+
+    function setMinTransferRootBondDelay(uint256 _minTransferRootBondDelay) external onlyGovernance {
+        minTransferRootBondDelay = _minTransferRootBondDelay;
     }
 
     /* ========== Public Getters ========== */

--- a/contracts/bridges/L2_ArbitrumBridge.sol
+++ b/contracts/bridges/L2_ArbitrumBridge.sol
@@ -46,4 +46,12 @@ contract L2_ArbitrumBridge is L2_Bridge {
         // ToDo: verify sender with Arbitrum L2 messenger
         // sender should be l1BridgeAddress
     }
+
+    /**
+     * @dev Allows the L1 Bridge to set the messenger
+     * @param _messenger The new messenger address
+     */
+    function setMessenger(IArbSys _messenger) external onlyL1Bridge {
+        messenger = _messenger;
+    }
 }

--- a/contracts/bridges/L2_OptimismBridge.sol
+++ b/contracts/bridges/L2_OptimismBridge.sol
@@ -51,4 +51,20 @@ contract L2_OptimismBridge is L2_Bridge {
         // Verify that cross-domain sender is expectedSender
         require(messenger.xDomainMessageSender() == expectedSender, "L2_OVM_BRG: Invalid cross-domain sender");
     }
+
+    /**
+     * @dev Allows the L1 Bridge to set the messenger
+     * @param _messenger The new messenger address
+     */
+    function setMessenger(iOVM_L2CrossDomainMessenger _messenger) external onlyL1Bridge {
+        messenger = _messenger;
+    }
+
+    /**
+     * @dev Allows the L1 Bridge to set the default gas limit
+     * @param _defaultGasLimit The new default gas limit
+     */
+    function setDefaultGasLimit(uint32 _defaultGasLimit) external onlyL1Bridge {
+        defaultGasLimit = _defaultGasLimit;
+    }
 }

--- a/contracts/bridges/L2_XDaiBridge.sol
+++ b/contracts/bridges/L2_XDaiBridge.sol
@@ -14,7 +14,6 @@ contract L2_XDaiBridge is L2_Bridge {
     iArbitraryMessageBridge public messenger;
     /// @notice The xDai AMB uses bytes32 for chainId instead of uint256
     bytes32 public l1ChainId;
-    address public ambBridge;
 
     constructor (
         iArbitraryMessageBridge _messenger,
@@ -24,8 +23,7 @@ contract L2_XDaiBridge is L2_Bridge {
         address l1BridgeAddress,
         uint256[] memory supportedChainIds,
         address[] memory bonders,
-        uint256 _l1ChainId,
-        address _ambBridge
+        uint256 _l1ChainId
     )
         public
         L2_Bridge(
@@ -39,7 +37,6 @@ contract L2_XDaiBridge is L2_Bridge {
     {
         messenger = _messenger;
         l1ChainId = bytes32(_l1ChainId);
-        ambBridge = _ambBridge;
     }
 
     function _sendCrossDomainMessage(bytes memory message) internal override {
@@ -52,10 +49,18 @@ contract L2_XDaiBridge is L2_Bridge {
 
     function _verifySender(address expectedSender) internal override {
         require(messenger.messageSender() == expectedSender);
-        require(msg.sender == ambBridge);
+        require(msg.sender == address(messenger));
 
         // With the xDai AMB, it is best practice to also check the source chainId
         // https://docs.tokenbridge.net/amb-bridge/how-to-develop-xchain-apps-by-amb#receive-a-method-call-from-the-amb-bridge
         require(messenger.messageSourceChainId() == l1ChainId);
+    }
+
+    /**
+     * @dev Allows the L1 Bridge to set the messenger
+     * @param _messenger The new messenger address
+     */
+    function setMessenger(iArbitraryMessageBridge _messenger) external onlyL1Bridge {
+        messenger = _messenger;
     }
 }

--- a/contracts/test/Mock_L2_XDaiBridge.sol
+++ b/contracts/test/Mock_L2_XDaiBridge.sol
@@ -17,8 +17,7 @@ contract Mock_L2_XDaiBridge is L2_XDaiBridge {
         address l1BridgeAddress,
         uint256[] memory supportedChainIds,
         address[] memory bonders,
-        uint256 l1ChainId,
-        address ambBridge
+        uint256 l1ChainId
     )
         public
         L2_XDaiBridge(
@@ -29,8 +28,7 @@ contract Mock_L2_XDaiBridge is L2_XDaiBridge {
             l1BridgeAddress,
             supportedChainIds,
             bonders,
-            l1ChainId,
-            ambBridge
+            l1ChainId
         )
     {
         chainId = _chainId;

--- a/test/bridges/Accounting.test.ts
+++ b/test/bridges/Accounting.test.ts
@@ -217,16 +217,6 @@ describe('Accounting', () => {
     ).to.be.revertedWith(expectedErrorMsg)
   })
 
-  it('Should not allow someone outside of the bonder to unstake', async () => {
-    const expectedErrorMsg: string = 'ACT: Caller is not bonder'
-    const stakeAmount: BigNumber = BigNumber.from(10)
-
-    await mockAccounting.stake(await bonder.getAddress(), stakeAmount)
-    await expect(mockAccounting.unstake(stakeAmount)).to.be.revertedWith(
-      expectedErrorMsg
-    )
-  })
-
   it('Should not allow someone to stake on a non-bonder address', async () => {
     const expectedErrorMsg: string =
       'VM Exception while processing transaction: revert ACT: Address is not bonder'

--- a/test/shared/contractFunctionWrappers.ts
+++ b/test/shared/contractFunctionWrappers.ts
@@ -659,6 +659,8 @@ export const executeL1BridgeResolveChallenge = async (
     let expectedCredit: BigNumber = creditBefore.add(bondAmount)
     if (didBonderWaitMinTransferRootTime) {
       expectedCredit = expectedCredit.add(challengeAmount)
+    } else {
+      await l1_bridge.connect(challenger).unstake(challengeAmount)
     }
     expect(creditAfter).to.eq(expectedCredit)
   } else {
@@ -677,11 +679,12 @@ export const executeL1BridgeResolveChallenge = async (
         .toString()
     )
 
+    const expectedChallengerBalance = challengeAmount.mul(7).div(4)
+    await l1_bridge.connect(challenger).unstake(expectedChallengerBalance)
+
     // Challenger should have tokens
     // NOTE: the challenge amount is subtracted to mimic the amount sent to the contract during the challenge
-    const expectedChallengerTokenAmount: BigNumber = challengerBalanceBefore.add(
-      challengeAmount.mul(7).div(4)
-    )
+    const expectedChallengerTokenAmount: BigNumber = challengerBalanceBefore.add(expectedChallengerBalance)
     await expectBalanceOf(
       l1_canonicalToken,
       challenger,


### PR DESCRIPTION
* Make deep copy of transferIds because getMerkleRoot mutates it
* Add messenger setters to L2_Bridges
* only settle non-zero amounts
*  Pull style payments for the challenger
* Make minTransferRootBondDelay configurable for testing purposes