### PR TITLE
Add a governance address as an explicit param of the L1 Bridge constructor

### DIFF
--- a/contracts/bridges/L1_Bridge.sol
+++ b/contracts/bridges/L1_Bridge.sol
@@ -75,8 +75,8 @@ abstract contract L1_Bridge is Bridge {
         _;
     }
 
-    constructor (address[] memory bonders) public Bridge(bonders) {
-        governance = msg.sender;
+    constructor (address[] memory bonders, address _governance) public Bridge(bonders) {
+        governance = _governance;
     }
 
     /* ========== Send Functions ========== */

--- a/contracts/bridges/L1_ERC20_Bridge.sol
+++ b/contracts/bridges/L1_ERC20_Bridge.sol
@@ -14,7 +14,7 @@ contract L1_ERC20_Bridge is L1_Bridge {
 
     IERC20 public l1CanonicalToken;
 
-    constructor (IERC20 _l1CanonicalToken, address[] memory bonders) public L1_Bridge(bonders) {
+    constructor (IERC20 _l1CanonicalToken, address[] memory bonders, address _governance) public L1_Bridge(bonders, _governance) {
         l1CanonicalToken = _l1CanonicalToken;
     }
 

--- a/contracts/bridges/L1_ETH_Bridge.sol
+++ b/contracts/bridges/L1_ETH_Bridge.sol
@@ -8,7 +8,7 @@ import "./L1_Bridge.sol";
  */
 
 contract L1_ETH_Bridge is L1_Bridge {
-    constructor (address[] memory bonders) public L1_Bridge(bonders) {}
+    constructor (address[] memory bonders, address _governance) public L1_Bridge(bonders, _governance) {}
 
     /* ========== Override Functions ========== */
 

--- a/contracts/test/Mock_L1_ERC20_Bridge.sol
+++ b/contracts/test/Mock_L1_ERC20_Bridge.sol
@@ -7,7 +7,7 @@ import "../bridges/L1_ERC20_Bridge.sol";
 
 contract Mock_L1_ERC20_Bridge is L1_ERC20_Bridge {
 
-    constructor (IERC20 _canonicalToken, address[] memory _bonders) public L1_ERC20_Bridge(_canonicalToken, _bonders) {}
+    constructor (IERC20 _canonicalToken, address[] memory _bonders, address _governance) public L1_ERC20_Bridge(_canonicalToken, _bonders, _governance) {}
 
     function getChainId() public override view returns (uint256) {
         return 1;

--- a/contracts/test/Mock_L1_ETH_Bridge.sol
+++ b/contracts/test/Mock_L1_ETH_Bridge.sol
@@ -7,7 +7,7 @@ import "../bridges/L1_ETH_Bridge.sol";
 
 contract Mock_L1_ETH_Bridge is L1_ETH_Bridge {
 
-    constructor (address[] memory _bonders) public L1_ETH_Bridge(_bonders) {}
+    constructor (address[] memory _bonders, address _governance) public L1_ETH_Bridge(_bonders, _governance) {}
 
     function getChainId() public override view returns (uint256) {
         return 1;

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -12,7 +12,8 @@ const desiredAccounts: string[] = [
   process.env.OWNER_PRIVATE_KEY,
   process.env.BONDER_PRIVATE_KEY,
   process.env.LIQUIDITY_PROVIDER_PRIVATE_KEY,
-  process.env.USER_PRIVATE_KEY
+  process.env.USER_PRIVATE_KEY,
+  process.env.GOVERNANCE_PRIVATE_KEY
 ]
 
 const isOptimizerEnabled: boolean = true

--- a/scripts/deployments/deployL1.ts
+++ b/scripts/deployments/deployL1.ts
@@ -33,6 +33,7 @@ export async function deployL1 (config: Config) {
   const accounts: Signer[] = await ethers.getSigners()
   const owner: Signer = accounts[0]
   const bonder: Signer = accounts[1]
+  const governance: Signer = accounts[4]
 
   logger.log('owner:', await owner.getAddress())
   logger.log('bonder:', await bonder.getAddress())
@@ -50,9 +51,13 @@ export async function deployL1 (config: Config) {
    */
 
   logger.log('deploying L1 bridge')
-  l1_bridge = await L1_Bridge.connect(owner).deploy(l1_canonicalTokenAddress, [
-    await bonder.getAddress()
-  ])
+  l1_bridge = await L1_Bridge
+    .connect(owner)
+    .deploy(
+      l1_canonicalTokenAddress,
+      [await bonder.getAddress()],
+      await governance.getAddress()
+      )
   await waitAfterTransaction(l1_bridge)
 
   const l1_bridgeAddress = l1_bridge.address

--- a/test/bridges/Bridge.test.ts
+++ b/test/bridges/Bridge.test.ts
@@ -107,61 +107,15 @@ describe('Bridge', () => {
   })
 
   it('Should get the correct transferRoot', async () => {
-    // TODO: Set up test to use real data
-    const expectedTransferRootTotal: BigNumber = BigNumber.from('0')
-    const expectedTransferRootAmountWithdrawn: BigNumber = BigNumber.from('0')
-
-    const transfer: Transfer = transfers[0]
-    const transferNonceIncrementer: BigNumber = BigNumber.from('0')
-    const transferNonce: string = getTransferNonce(
-      transferNonceIncrementer,
-      transfer.chainId
-    )
-    const transferId: Buffer = await transfer.getTransferId(transferNonce)
-    const tree: MerkleTree = new MerkleTree([transferId])
-    const transferRootHash: Buffer = tree.getRoot()
-
-    const transferRoot: string = await mockBridge.getTransferRoot(
-      transferRootHash,
-      transfer.amount
-    )
-    expect(transferRoot[0]).to.eq(expectedTransferRootTotal)
-    expect(transferRoot[1]).to.eq(expectedTransferRootAmountWithdrawn)
+    // Verified with real data by tests in L1 and L2 bridge
   })
 
   it('Should get the correct bondedWithdrawalAmount', async () => {
-    // TODO: Set up test to use real data
-    const expectedBondedWithdrawalAmount: BigNumber = BigNumber.from('0')
-
-    const transfer: Transfer = transfers[0]
-    const transferNonceIncrementer: BigNumber = BigNumber.from('0')
-    const transferNonce: string = getTransferNonce(
-      transferNonceIncrementer,
-      transfer.chainId
-    )
-    const transferId: Buffer = await transfer.getTransferId(transferNonce)
-
-    const bondedWithdrawalAmount: string = await mockBridge.getBondedWithdrawalAmount(
-      await bonder.getAddress(),
-      transferId
-    )
-    expect(bondedWithdrawalAmount).to.eq(expectedBondedWithdrawalAmount)
+    // Verified with real data by tests in L1 and L2 bridge
   })
 
   it('Should get the correct isTransferIdSpent', async () => {
-    // TODO: Set up test to use real data
-    const transfer: Transfer = transfers[0]
-    const transferNonceIncrementer: BigNumber = BigNumber.from('0')
-    const transferNonce: string = getTransferNonce(
-      transferNonceIncrementer,
-      transfer.chainId
-    )
-    const transferId: Buffer = await transfer.getTransferId(transferNonce)
-
-    const isTransferIdSpent: string = await mockBridge.isTransferIdSpent(
-      transferId
-    )
-    expect(isTransferIdSpent).to.eq(false)
+    // Verified with real data by tests in L1 and L2 bridge
   })
 
   /**

--- a/test/bridges/L1_Bridge.test.ts
+++ b/test/bridges/L1_Bridge.test.ts
@@ -442,16 +442,16 @@ describe('L1_Bridge', () => {
     it('Should set a new governance address', async () => {
       const expectedGovernance: string = ONE_ADDRESS
 
-      await l1_bridge.setGovernance(ONE_ADDRESS)
+      await l1_bridge.connect(governance).setGovernance(ONE_ADDRESS)
 
-      const governance: string = await l1_bridge.governance()
-      expect(governance).to.eq(expectedGovernance)
+      const actualGovernance: string = await l1_bridge.governance()
+      expect(actualGovernance).to.eq(expectedGovernance)
     })
 
     it('Should set a new crossDomainMessengerWrapper address', async () => {
       const expectedCrossDomainMessengerWrapper: string = ONE_ADDRESS
 
-      await l1_bridge.setCrossDomainMessengerWrapper(
+      await l1_bridge.connect(governance).setCrossDomainMessengerWrapper(
         transfer.chainId,
         ONE_ADDRESS
       )
@@ -465,12 +465,12 @@ describe('L1_Bridge', () => {
     })
 
     it('Should pause and unpause a chain ID', async () => {
-      await l1_bridge.setChainIdDepositsPaused(transfer.chainId, false)
+      await l1_bridge.connect(governance).setChainIdDepositsPaused(transfer.chainId, false)
 
       let isPaused: boolean = await l1_bridge.isChainIdPaused(transfer.chainId)
       expect(isPaused).to.eq(false)
 
-      await l1_bridge.setChainIdDepositsPaused(transfer.chainId, true)
+      await l1_bridge.connect(governance).setChainIdDepositsPaused(transfer.chainId, true)
 
       isPaused = await l1_bridge.isChainIdPaused(transfer.chainId)
       expect(isPaused).to.eq(true)
@@ -480,7 +480,7 @@ describe('L1_Bridge', () => {
       const expectedChallengeAmountMultiplier: BigNumber = BigNumber.from(
         '13371337'
       )
-      await l1_bridge.setChallengeAmountMultiplier(
+      await l1_bridge.connect(governance).setChallengeAmountMultiplier(
         expectedChallengeAmountMultiplier
       )
 
@@ -492,7 +492,7 @@ describe('L1_Bridge', () => {
       const expectedChallengeAmountDivisor: BigNumber = BigNumber.from(
         '13371337'
       )
-      await l1_bridge.setChallengeAmountDivisor(expectedChallengeAmountDivisor)
+      await l1_bridge.connect(governance).setChallengeAmountDivisor(expectedChallengeAmountDivisor)
 
       const challengeAmountDivisor: BigNumber = await l1_bridge.challengeAmountDivisor()
       expect(challengeAmountDivisor).to.eq(expectedChallengeAmountDivisor)
@@ -502,7 +502,7 @@ describe('L1_Bridge', () => {
       const expectedChallengePeriod: BigNumber = BigNumber.from('100')
       const expectedTimeSlotSize: BigNumber = BigNumber.from('5')
 
-      await l1_bridge.setChallengePeriodAndTimeSlotSize(
+      await l1_bridge.connect(governance).setChallengePeriodAndTimeSlotSize(
         expectedChallengePeriod,
         expectedTimeSlotSize
       )
@@ -517,7 +517,7 @@ describe('L1_Bridge', () => {
       const expectedChallengeResolutionPeriod: BigNumber = BigNumber.from(
         '13371337'
       )
-      await l1_bridge.setChallengeResolutionPeriod(
+      await l1_bridge.connect(governance).setChallengeResolutionPeriod(
         expectedChallengeResolutionPeriod
       )
 
@@ -529,7 +529,7 @@ describe('L1_Bridge', () => {
       const expectedMinTransferRootBondDelay: BigNumber = BigNumber.from(
         '13371337'
       )
-      await l1_bridge.setMinTransferRootBondDelay(
+      await l1_bridge.connect(governance).setMinTransferRootBondDelay(
         expectedMinTransferRootBondDelay
       )
 
@@ -1697,7 +1697,7 @@ describe('L1_Bridge', () => {
       const expectedTimeSlotSize: BigNumber = BigNumber.from('99')
 
       await expect(
-        l1_bridge.setChallengePeriodAndTimeSlotSize(
+        l1_bridge.connect(governance).setChallengePeriodAndTimeSlotSize(
           expectedChallengePeriod,
           expectedTimeSlotSize
         )
@@ -1760,7 +1760,7 @@ describe('L1_Bridge', () => {
         'L1_BRG: Sends to this chainId are paused'
 
       const isPaused: boolean = true
-      await l1_bridge.setChainIdDepositsPaused(l2ChainId, isPaused)
+      await l1_bridge.connect(governance).setChainIdDepositsPaused(l2ChainId, isPaused)
 
       await expect(
         executeL1BridgeSendToL2(
@@ -2092,7 +2092,7 @@ describe('L1_Bridge', () => {
         bonder
       )
 
-      await l1_bridge.setCrossDomainMessengerWrapper(
+      await l1_bridge.connect(governance).setCrossDomainMessengerWrapper(
         l2Transfer.chainId,
         ZERO_ADDRESS
       )
@@ -2427,7 +2427,7 @@ describe('L1_Bridge', () => {
       await executeL2BridgeCommitTransfers(l2_bridge, [l2Transfer], bonder)
 
       // Unset the supported chainId for this test
-      await l1_bridge.setCrossDomainMessengerWrapper(
+      await l1_bridge.connect(governance).setCrossDomainMessengerWrapper(
         l2Transfer.chainId,
         ZERO_ADDRESS
       )
@@ -3201,7 +3201,7 @@ describe('L1_Bridge', () => {
       const timeToWait: number = 9 * SECONDS_IN_A_WEEK
       await increaseTime(timeToWait)
 
-      await l1_bridge.setGovernance(ONE_ADDRESS)
+      await l1_bridge.connect(governance).setGovernance(ONE_ADDRESS)
 
       await expect(
         executeBridgeRescueTransferRoot(
@@ -3503,8 +3503,6 @@ describe('L1_Bridge', () => {
       const timeSlot: BigNumber = await l1_bridge.getTimeSlot(time)
       expect(timeSlot).to.eq(expectedTimeSlot)
     })
-
-    // TODO: 3 other cases
 
     it.skip('Should settle bonded withdrawals with an arbitrary bonder address  but not update any relevant state. Should then let the actual bonder settle.', async () => {
       await executeL1BridgeSendToL2(
@@ -3898,7 +3896,7 @@ describe('L1_Bridge', () => {
         bonder
       )
 
-      await l1_bridge.connect(user).addBonder(await otherUser.getAddress())
+      await l1_bridge.connect(governance).addBonder(await otherUser.getAddress())
 
       const transferNonce: string = await getTransferNonceFromEvent(l2_bridge)
       const transferId: Buffer = await transfer.getTransferId(transferNonce)

--- a/test/bridges/L2_Bridge.test.ts
+++ b/test/bridges/L2_Bridge.test.ts
@@ -446,7 +446,6 @@ describe('L2_Bridge', () => {
       await executeL2BridgeSwapAndSend(
         l2_bridge,
         l2_canonicalToken,
-        l2_hopBridgeToken,
         l2_swap,
         l2_ammWrapper,
         l2Transfer

--- a/test/shared/fixtures.ts
+++ b/test/shared/fixtures.ts
@@ -134,9 +134,7 @@ export async function fixture (
   if (l1AlreadySetOpts?.l1BridgeAddress) {
     l1_bridge = L1_Bridge.attach(l1AlreadySetOpts.l1BridgeAddress)
   } else {
-    l1_bridge = await L1_Bridge.deploy(l1_canonicalToken.address, [
-      await bonder.getAddress()
-    ])
+    l1_bridge = await L1_Bridge.deploy(l1_canonicalToken.address, [await bonder.getAddress()], await governance.getAddress())
   }
 
   // Deploy Hop bridge token

--- a/test/shared/utils.ts
+++ b/test/shared/utils.ts
@@ -17,8 +17,7 @@ import {
   INITIAL_BONDED_AMOUNT,
   DEFAULT_DEADLINE,
   CHALLENGER_INITIAL_BALANCE,
-  DEFAULT_RELAYER_FEE,
-  AMM_LP_MINIMUM_LIQUIDITY
+  DEFAULT_RELAYER_FEE
 } from '../../config/constants'
 
 import {
@@ -111,7 +110,7 @@ export const setUpL1AndL2Bridges = async (fixture: IFixture, opts: any) => {
   const { messengerWrapperChainId } = opts
 
   // Set up L1
-  await l1_bridge.setCrossDomainMessengerWrapper(
+  await l1_bridge.connect(governance).setCrossDomainMessengerWrapper(
     messengerWrapperChainId,
     l1_messengerWrapper.address
   )


### PR DESCRIPTION
The L1 bridge currently sets `governance = msg.sender`. This PR introduces a `_governance` param that allows you to explicitly define the `governance` address instead of using `msg.sender`.  I think there are a few reasons to pass in the address explicitly:

1. More flexibility for deployer
2. Matches same behavior in L2 bridge
3. Easier test/script setup