### PR TITLE
Move the L2 Bridge messengerGasLimit and setter to XDai

### DIFF
--- a/config/constants.ts
+++ b/config/constants.ts
@@ -37,8 +37,8 @@ export const MAX_APPROVAL: BigNumber = BigNumber.from(
   '0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
 )
 
-export const DEFAULT_L2_BRIDGE_GAS_LIMIT: number = 8000000
-export const DEFAULT_MESSENGER_WRAPPER_GAS_LIMIT: number = DEFAULT_L2_BRIDGE_GAS_LIMIT
+export const DEFAULT_L2_BRIDGE_GAS_LIMIT: number = 250000
+export const DEFAULT_MESSENGER_WRAPPER_GAS_LIMIT: number = 8000000
 export const DEFAULT_MESSENGER_WRAPPER_GAS_PRICE: number = 0
 export const DEFAULT_MESSENGER_WRAPPER_GAS_CALL_VALUE: number = 0
 

--- a/config/utils.ts
+++ b/config/utils.ts
@@ -7,7 +7,8 @@ import {
   CHAIN_IDS,
   DEFAULT_MESSENGER_WRAPPER_GAS_LIMIT,
   DEFAULT_MESSENGER_WRAPPER_GAS_PRICE,
-  DEFAULT_MESSENGER_WRAPPER_GAS_CALL_VALUE
+  DEFAULT_MESSENGER_WRAPPER_GAS_CALL_VALUE,
+  DEFAULT_L2_BRIDGE_GAS_LIMIT
 } from './constants'
 
 export const getMessengerWrapperDefaults = (
@@ -63,10 +64,13 @@ export const getL2BridgeDefaults = (
 
   if (isChainIdArbitrum(chainId)) {
   } else if (isChainIdOptimism(chainId)) {
-    const defaultGasLimit = DEFAULT_MESSENGER_WRAPPER_GAS_LIMIT
+    const defaultGasLimit = DEFAULT_L2_BRIDGE_GAS_LIMIT
     additionalData.push(defaultGasLimit)
   } else if (isChainIdXDai(chainId)) {
-    additionalData.push(l1ChainId)
+    additionalData.push(
+      l1ChainId,
+      DEFAULT_L2_BRIDGE_GAS_LIMIT
+    )
   }
 
   defaults.push(

--- a/contracts/bridges/L2_Bridge.sol
+++ b/contracts/bridges/L2_Bridge.sol
@@ -29,7 +29,6 @@ abstract contract L2_Bridge is Bridge, ReentrancyGuard {
     IERC20 public l2CanonicalToken;
     mapping(uint256 => bool) public supportedChainIds;
     uint256 public minimumForceCommitDelay = 4 hours;
-    uint256 public messengerGasLimit = 250000;
     uint256 public maxPendingTransfers = 100;
     uint256 public minBonderBps = 2;
     uint256 public minBonderFeeAbsolute = 0;
@@ -312,10 +311,6 @@ abstract contract L2_Bridge is Bridge, ReentrancyGuard {
 
     function setL1MessengerWrapperAddress(address _l1MessengerWrapperAddress) external onlyGovernance {
         l1MessengerWrapperAddress = _l1MessengerWrapperAddress;
-    }
-
-    function setMessengerGasLimit(uint256 _messengerGasLimit) external onlyGovernance {
-        messengerGasLimit = _messengerGasLimit;
     }
 
     function addSupportedChainIds(uint256[] calldata chainIds) external onlyGovernance {

--- a/contracts/bridges/L2_XDaiBridge.sol
+++ b/contracts/bridges/L2_XDaiBridge.sol
@@ -14,6 +14,7 @@ contract L2_XDaiBridge is L2_Bridge {
     iArbitraryMessageBridge public messenger;
     /// @notice The xDai AMB uses bytes32 for chainId instead of uint256
     bytes32 public l1ChainId;
+    uint256 public messengerGasLimit;
 
     constructor (
         iArbitraryMessageBridge _messenger,
@@ -22,7 +23,8 @@ contract L2_XDaiBridge is L2_Bridge {
         address l1BridgeAddress,
         uint256[] memory supportedChainIds,
         address[] memory bonders,
-        uint256 _l1ChainId
+        uint256 _l1ChainId,
+        uint256 _messengerGasLimit
     )
         public
         L2_Bridge(
@@ -35,6 +37,7 @@ contract L2_XDaiBridge is L2_Bridge {
     {
         messenger = _messenger;
         l1ChainId = bytes32(_l1ChainId);
+        messengerGasLimit = _messengerGasLimit;
     }
 
     function _sendCrossDomainMessage(bytes memory message) internal override {
@@ -60,5 +63,9 @@ contract L2_XDaiBridge is L2_Bridge {
      */
     function setMessenger(iArbitraryMessageBridge _messenger) external onlyL1Bridge {
         messenger = _messenger;
+    }
+
+    function setMessengerGasLimit(uint256 _messengerGasLimit) external onlyGovernance {
+        messengerGasLimit = _messengerGasLimit;
     }
 }


### PR DESCRIPTION
Move `setMesegnerGasLimit()` from L2_Bridge to L2_XDaiBridge since it is only used there. I believe it makes sense to do this and it matches the L2_OptimismBridge architecture.