### PR TITLE
Feature/l2 specific bridge updates

### DIFF
--- a/contracts/bridges/L2_ArbitrumBridge.sol
+++ b/contracts/bridges/L2_ArbitrumBridge.sol
@@ -49,7 +49,7 @@ contract L2_ArbitrumBridge is L2_Bridge {
      * @dev Allows the L1 Bridge to set the messenger
      * @param _messenger The new messenger address
      */
-    function setMessenger(IArbSys _messenger) external onlyL1Bridge {
+    function setMessenger(IArbSys _messenger) external onlyGovernance {
         messenger = _messenger;
     }
 }

--- a/contracts/bridges/L2_OptimismBridge.sol
+++ b/contracts/bridges/L2_OptimismBridge.sol
@@ -54,7 +54,7 @@ contract L2_OptimismBridge is L2_Bridge {
      * @dev Allows the L1 Bridge to set the messenger
      * @param _messenger The new messenger address
      */
-    function setMessenger(iOVM_L2CrossDomainMessenger _messenger) external onlyL1Bridge {
+    function setMessenger(iOVM_L2CrossDomainMessenger _messenger) external onlyGovernance {
         messenger = _messenger;
     }
 
@@ -62,7 +62,7 @@ contract L2_OptimismBridge is L2_Bridge {
      * @dev Allows the L1 Bridge to set the default gas limit
      * @param _defaultGasLimit The new default gas limit
      */
-    function setDefaultGasLimit(uint32 _defaultGasLimit) external onlyL1Bridge {
+    function setDefaultGasLimit(uint32 _defaultGasLimit) external onlyGovernance {
         defaultGasLimit = _defaultGasLimit;
     }
 }

--- a/contracts/bridges/L2_PolygonBridge.sol
+++ b/contracts/bridges/L2_PolygonBridge.sol
@@ -49,7 +49,7 @@ contract L2_PolygonBridge is L2_Bridge {
      * @dev Allows the L1 Bridge to set the messengerProxy proxy
      * @param _messengerProxy The new messengerProxy address
      */
-    function setMessengerProxy(L2_PolygonMessengerProxy _messengerProxy) external onlyL1Bridge {
+    function setMessengerProxy(L2_PolygonMessengerProxy _messengerProxy) external onlyGovernance {
         messengerProxy = _messengerProxy;
     }
 }

--- a/contracts/bridges/L2_XDaiBridge.sol
+++ b/contracts/bridges/L2_XDaiBridge.sol
@@ -46,12 +46,12 @@ contract L2_XDaiBridge is L2_Bridge {
     }
 
     function _verifySender(address expectedSender) internal override {
-        require(messenger.messageSender() == expectedSender);
-        require(msg.sender == address(messenger));
+        require(messenger.messageSender() == expectedSender, "L2_XDAI_BRG: Invalid cross-domain sender");
+        require(msg.sender == address(messenger), "L2_XDAI_BRG: Caller is not the expected sender");
 
         // With the xDai AMB, it is best practice to also check the source chainId
         // https://docs.tokenbridge.net/amb-bridge/how-to-develop-xchain-apps-by-amb#receive-a-method-call-from-the-amb-bridge
-        require(messenger.messageSourceChainId() == l1ChainId);
+        require(messenger.messageSourceChainId() == l1ChainId, "L2_XDAI_BRG: Invalid source Chain ID");
     }
 
     /**

--- a/contracts/bridges/L2_XDaiBridge.sol
+++ b/contracts/bridges/L2_XDaiBridge.sol
@@ -58,7 +58,7 @@ contract L2_XDaiBridge is L2_Bridge {
      * @dev Allows the L1 Bridge to set the messenger
      * @param _messenger The new messenger address
      */
-    function setMessenger(iArbitraryMessageBridge _messenger) external onlyL1Bridge {
+    function setMessenger(iArbitraryMessageBridge _messenger) external onlyGovernance {
         messenger = _messenger;
     }
 }

--- a/contracts/test/MockMessenger.sol
+++ b/contracts/test/MockMessenger.sol
@@ -20,14 +20,26 @@ abstract contract MockMessenger {
 
     Message public nextMessage;
     IERC20 public canonicalToken;
+
+    /**
+     * Chain specific params
+     */
+
+    // Optimism
     address public xDomainMessageSender;
+
+    // XDai
+    address public messageSender;
+    bytes32 public messageSourceChainId = 0x000000000000000000000000000000000000000000000000000000000000002a;
 
     constructor(IERC20 _canonicalToken) public {
         canonicalToken = _canonicalToken;
     }
 
     function relayNextMessage() public {
+        messageSender = nextMessage.sender;
         xDomainMessageSender = nextMessage.sender;
+
         (bool success, bytes memory res) = nextMessage.target.call(nextMessage.message);
         require(success, _getRevertMsgFromRes(res));
     }

--- a/contracts/test/Mock_L1_Messenger.sol
+++ b/contracts/test/Mock_L1_Messenger.sol
@@ -87,4 +87,27 @@ contract Mock_L1_Messenger is MockMessenger {
             msg.sender
         );
     }
+
+    /* ========== xDai ========== */
+
+    function requireToPassMessage(
+        address _target,
+        bytes calldata _message,
+        uint256 _gasLimit
+    )
+        public
+        returns (bytes32)
+    {
+        targetMessenger.receiveMessage(
+            _target,
+            _message,
+            msg.sender
+        );
+
+        return bytes32('0');
+    }
+
+    /* ========== Polygon ========== */
+
+    // TODO
 }

--- a/contracts/test/Mock_L2_Messenger.sol
+++ b/contracts/test/Mock_L2_Messenger.sol
@@ -48,4 +48,27 @@ contract Mock_L2_Messenger is MockMessenger {
             msg.sender
         );
     }
+
+    /* ========== xDai ========== */
+
+    function requireToPassMessage(
+        address _target,
+        bytes calldata _message,
+        uint256 _gasLimit
+    )
+        public
+        returns (bytes32)
+    {
+        targetMessenger.receiveMessage(
+            _target,
+            _message,
+            msg.sender
+        );
+
+        return bytes32(0);
+    }
+
+    /* ========== Polygon ========== */
+
+    // TODO
 }

--- a/contracts/wrappers/XDaiMessengerWrapper.sol
+++ b/contracts/wrappers/XDaiMessengerWrapper.sol
@@ -44,7 +44,7 @@ contract XDaiMessengerWrapper is MessengerWrapper {
         l1MessengerAddress.requireToPassMessage(
             l2BridgeAddress,
             _calldata,
-            uint32(defaultGasLimit)
+            defaultGasLimit
         );
     }
 

--- a/contracts/wrappers/XDaiMessengerWrapper.sol
+++ b/contracts/wrappers/XDaiMessengerWrapper.sol
@@ -50,11 +50,11 @@ contract XDaiMessengerWrapper is MessengerWrapper {
 
     /// @notice message data is not needed for message verification with the xDai AMB
     function verifySender(address l1BridgeCaller, bytes memory) public override {
-        require(l1MessengerAddress.messageSender() == l2BridgeAddress);
-        require(l1BridgeCaller == ambBridge);
+        require(l1MessengerAddress.messageSender() == l2BridgeAddress, "L2_XDAI_BRG: Invalid cross-domain sender");
+        require(l1BridgeCaller == ambBridge, "L2_XDAI_BRG: Caller is not the expected sender");
 
         // With the xDai AMB, it is best practice to also check the source chainId
         // https://docs.tokenbridge.net/amb-bridge/how-to-develop-xchain-apps-by-amb#receive-a-method-call-from-the-amb-bridge
-        require(l1MessengerAddress.messageSourceChainId() == l2ChainId);
+        require(l1MessengerAddress.messageSourceChainId() == l2ChainId, "L2_XDAI_BRG: Invalid source Chain ID");
     }
 }

--- a/test/bridges/L2_XDaiBridge.test.ts
+++ b/test/bridges/L2_XDaiBridge.test.ts
@@ -65,7 +65,7 @@ import {
   DEFAULT_RELAYER_FEE
 } from '../../config/constants'
 
-describe.skip('L2_XDai_Bridge', () => {
+describe('L2_XDai_Bridge', () => {
   let _fixture: IFixture
   let l1ChainId: BigNumber
   let l2ChainId: BigNumber
@@ -102,8 +102,7 @@ describe.skip('L2_XDai_Bridge', () => {
     beforeAllSnapshotId = await takeSnapshot()
 
     l1ChainId = CHAIN_IDS.ETHEREUM.KOVAN
-    // TODO: Fix this for XDai
-    // l2ChainId = CHAIN_IDS.XDAI.SOKOL
+    l2ChainId = CHAIN_IDS.XDAI.SOKOL
 
     _fixture = await fixture(l1ChainId, l2ChainId)
     await setUpDefaults(_fixture, l2ChainId)
@@ -226,14 +225,14 @@ describe.skip('L2_XDai_Bridge', () => {
    */
 
   it('Should not set an arbitrary messenger because the transaction was on L2 directly', async () => {
-    const expectedErrorMsg: string = 'TODO'
+    const expectedErrorMsg: string = 'L2_XDAI_BRG: Invalid cross-domain sender'
 
     const expectedMessengerAddress: string = ONE_ADDRESS
     await expect(l2_bridge.setMessenger(expectedMessengerAddress)).to.be.revertedWith(expectedErrorMsg)
   })
 
   it('Should not set an arbitrary messenger because the transaction was not sent by governance', async () => {
-    const expectedErrorMsg: string = 'TODO'
+    const expectedErrorMsg: string = 'L2_XDAI_BRG: Invalid cross-domain sender'
 
     const expectedMessengerAddress: string = ONE_ADDRESS
 

--- a/test/shared/utils.ts
+++ b/test/shared/utils.ts
@@ -124,7 +124,8 @@ export const setUpL1AndL2Bridges = async (fixture: IFixture, opts: any) => {
     l2_bridge,
     l2_messenger,
     governance,
-    message
+    message,
+    messengerWrapperChainId
   )
 
   message = getSetL1MessengerWrapperAddressMessage(l1_messengerWrapper)
@@ -133,7 +134,8 @@ export const setUpL1AndL2Bridges = async (fixture: IFixture, opts: any) => {
     l2_bridge,
     l2_messenger,
     governance,
-    message
+    message,
+    messengerWrapperChainId
   )
 
   message = getSetAmmWrapperAddressMessage(l2_ammWrapper)
@@ -142,7 +144,8 @@ export const setUpL1AndL2Bridges = async (fixture: IFixture, opts: any) => {
     l2_bridge,
     l2_messenger,
     governance,
-    message
+    message,
+    messengerWrapperChainId
   )
 }
 


### PR DESCRIPTION
Makes a few XDai specific changes and modifier changes:

* Add revert messages to XDai_MessengerWrapper.sol
* Add revert messages to L2_XDai_Bridge.sol
* Use correct XDai L1 messenger interface
* Decorate L2_xxx_Bridge.sol state vars with `onlyGovernance` instead of `onlyL1Bridge`