### PR TITLE
Feature/audit fixes 3

### DIFF
--- a/contracts/bridges/L2_AmmWrapper.sol
+++ b/contracts/bridges/L2_AmmWrapper.sol
@@ -10,11 +10,11 @@ import "../interfaces/IWETH.sol";
 
 contract L2_AmmWrapper {
 
-    L2_Bridge public bridge;
-    IERC20 public l2CanonicalToken;
-    bool public l2CanonicalTokenIsEth;
-    IERC20 public hToken;
-    Swap public exchangeAddress;
+    L2_Bridge public immutable bridge;
+    IERC20 public immutable l2CanonicalToken;
+    bool public immutable l2CanonicalTokenIsEth;
+    IERC20 public immutable hToken;
+    Swap public immutable exchangeAddress;
 
     /// @notice When l2CanonicalTokenIsEth is true, l2CanonicalToken should be set to the WETH address
     constructor(

--- a/contracts/bridges/L2_Bridge.sol
+++ b/contracts/bridges/L2_Bridge.sol
@@ -343,6 +343,7 @@ abstract contract L2_Bridge is Bridge, ReentrancyGuard {
     }
 
     function setMinimumBonderFeeRequirements(uint256 _minBonderBps, uint256 _minBonderFeeAbsolute) external onlyGovernance {
+        require(_minBonderBps <= 10000, "L2_BRG: minBonderBps must not exceed 10000");
         minBonderBps = _minBonderBps;
         minBonderFeeAbsolute = _minBonderFeeAbsolute;
     }

--- a/contracts/bridges/L2_Bridge.sol
+++ b/contracts/bridges/L2_Bridge.sol
@@ -114,7 +114,7 @@ abstract contract L2_Bridge is Bridge, ReentrancyGuard {
     {
         require(amount > 0, "L2_BRG: Must transfer a non-zero amount");
         require(amount >= bonderFee, "L2_BRG: Bonder fee cannot exceed amount");
-        require(supportedChainIds[chainId], "L2_BRG: _chainId is not supported");
+        require(supportedChainIds[chainId], "L2_BRG: chainId is not supported");
         uint256 minBonderFeeRelative = amount.mul(minBonderBps).div(10000);
         // Get the max of minBonderFeeRelative and minBonderFeeAbsolute
         uint256 minBonderFee = minBonderFeeRelative > minBonderFeeAbsolute ? minBonderFeeRelative : minBonderFeeAbsolute;

--- a/test/bridges/L2_Bridge.test.ts
+++ b/test/bridges/L2_Bridge.test.ts
@@ -395,7 +395,7 @@ describe('L2_Bridge', () => {
     })
 
     it('Should set the minimum bonder fee requirements', async () => {
-      const expectedMinBonderBps: BigNumber = BigNumber.from('13371337')
+      const expectedMinBonderBps: BigNumber = BigNumber.from('123')
       const expectedMinBonderFeeAbsolute: BigNumber = BigNumber.from('73317331')
 
       const message: string = getSetMinimumBonderFeeRequirementsMessage(
@@ -853,6 +853,26 @@ describe('L2_Bridge', () => {
           l2_bridge,
           l2_messenger,
           user,
+          message
+        )
+      ).to.be.revertedWith(expectedErrorMsg)
+    })
+
+    it('Should not allow minimum bonder BPS to exceed 10,000', async () => {
+      const expectedErrorMsg: string = 'L2_BRG: minBonderBps must not exceed 1000'
+      const expectedMinBonderBps: BigNumber = BigNumber.from('13371337')
+      const expectedMinBonderFeeAbsolute: BigNumber = BigNumber.from('73317331')
+
+      const message: string = getSetMinimumBonderFeeRequirementsMessage(
+        expectedMinBonderBps,
+        expectedMinBonderFeeAbsolute
+      )
+      await expect(
+        executeCanonicalMessengerSendMessage(
+          l1_messenger,
+          l2_bridge,
+          l2_messenger,
+          governance,
           message
         )
       ).to.be.revertedWith(expectedErrorMsg)

--- a/test/bridges/L2_Bridge.test.ts
+++ b/test/bridges/L2_Bridge.test.ts
@@ -879,7 +879,7 @@ describe('L2_Bridge', () => {
     })
 
     it('Should not allow a send to an unsupported chainId', async () => {
-      const expectedErrorMsg: string = 'L2_BRG: _chainId is not supported'
+      const expectedErrorMsg: string = 'L2_BRG: chainId is not supported'
       const customTransfer: Transfer = new Transfer(transfer)
       customTransfer.chainId = BigNumber.from('1337')
       await expect(


### PR DESCRIPTION
Audit fixes:

* Add immutable keyword to L2_AMMWrapper state variables
* Update revert message to use correct variable name
* Enforce a maximum minBonderBps