### PR TITLE
Update L2_Bridge.commitTransfer delay in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,13 @@ If the bonder is offline, the system relies on the canonical layer-2 bridge to s
 - **L2 -> L1 (bonder offline)**
 
   - User calls `L2_Bridge.swapAndSend()`
-  - `L2_Bridge.commitTransfer()` is called by anyone after 1 day
+  - 128 transactions are sent or `L2_Bridge.commitTransfer()` is called by anyone after 1 day
   - Wait for the sending layer-2 to be confirmed on layer-1 (approximately 7 days)
   - User or Relayer calls `L1_Bridge.withdraw()`
 
 - **L2 -> L2 (bonder offline)**
   - User calls `L2_Bridge.swapAndSend()` on the sending layer-2
-  - `L2_Bridge.commitTransfer()` is called on the sending layer-2 by anyone after 1 day
+  - 128 transactions are sent or `L2_Bridge.commitTransfer()` is called by anyone after 1 day on the sending layer-2
   - Wait for the sending layer-2 to be confirmed on layer-1 (approximately 7 days)
   - User or Relayer calls `L2_Bridge.withdraw()` on the receiving layer-2
 

--- a/README.md
+++ b/README.md
@@ -96,13 +96,13 @@ If the bonder is offline, the system relies on the canonical layer-2 bridge to s
 - **L2 -> L1 (bonder offline)**
 
   - User calls `L2_Bridge.swapAndSend()`
-  - `L2_Bridge.commitTransfer()` is called by anyone after 100 txs or after 4 hours
+  - `L2_Bridge.commitTransfer()` is called by anyone after 1 day
   - Wait for the sending layer-2 to be confirmed on layer-1 (approximately 7 days)
   - User or Relayer calls `L1_Bridge.withdraw()`
 
 - **L2 -> L2 (bonder offline)**
   - User calls `L2_Bridge.swapAndSend()` on the sending layer-2
-  - `L2_Bridge.commitTransfer()` is called on the sending layer-2 by anyone after 100 txs or after 4 hours
+  - `L2_Bridge.commitTransfer()` is called on the sending layer-2 by anyone after 1 day
   - Wait for the sending layer-2 to be confirmed on layer-1 (approximately 7 days)
   - User or Relayer calls `L2_Bridge.withdraw()` on the receiving layer-2
 

--- a/README.md
+++ b/README.md
@@ -96,13 +96,13 @@ If the bonder is offline, the system relies on the canonical layer-2 bridge to s
 - **L2 -> L1 (bonder offline)**
 
   - User calls `L2_Bridge.swapAndSend()`
-  - 128 transactions are sent or `L2_Bridge.commitTransfer()` is called by anyone after 1 day
+  - 512 transactions are sent or `L2_Bridge.commitTransfer()` is called by anyone after 1 day
   - Wait for the sending layer-2 to be confirmed on layer-1 (approximately 7 days)
   - User or Relayer calls `L1_Bridge.withdraw()`
 
 - **L2 -> L2 (bonder offline)**
   - User calls `L2_Bridge.swapAndSend()` on the sending layer-2
-  - 128 transactions are sent or `L2_Bridge.commitTransfer()` is called by anyone after 1 day on the sending layer-2
+  - 512 transactions are sent or `L2_Bridge.commitTransfer()` is called by anyone after 1 day on the sending layer-2
   - Wait for the sending layer-2 to be confirmed on layer-1 (approximately 7 days)
   - User or Relayer calls `L2_Bridge.withdraw()` on the receiving layer-2
 


### PR DESCRIPTION
The README says 100 txs or 4 hours but the code requires 1 day and doesn't count transactions.
https://github.com/hop-protocol/contracts/blob/f4c4746ab2be3eb7107d8f031ca3c501a69bd79f/contracts/bridges/L2_Bridge.sol#L181
https://github.com/hop-protocol/contracts/blob/f4c4746ab2be3eb7107d8f031ca3c501a69bd79f/contracts/bridges/L2_Bridge.sol#L27